### PR TITLE
Targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 
 .remake/*
+*/out/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,5 +1,5 @@
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
+download_nwis_data <- function(site_nums = c("01427207", "01432160", "01436690", "01466500")){ # removing "01435000"
   
   # create the file names that are needed for download_nwis_site_data
   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
@@ -23,7 +23,21 @@ nwis_site_info <- function(fileout, site_data){
   write_csv(site_info, fileout)
 }
 
+#' Combine NWIS files for specified gages
+#' 
+#' Returns a table of NWIS data from user-specified gages
+#' 
+#' @param ... all upstream targets that should be combined for use in the downstream `site_data` target
+#' 
+combine_site_data <- function(...){
+  files_in <- c(...)
+  data <- lapply(files_in, readr::read_csv, col_types = 'ccTdcc') %>% bind_rows()
+  
+  return(data)
+}
 
+#' a helper function called internally by `download_nwis_data()`
+#' 
 download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
   
   # filepaths look something like directory/nwis_01432160_data.csv,
@@ -41,7 +55,7 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, path = filepath)
+  write_csv(data_out, file = filepath)
   return(filepath)
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -17,6 +17,13 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01436690",
   return(data_out)
 }
 
+#' Get NWIS site data info
+#' 
+#' Returns site metadata for all NWIS gages included in `site_data` target
+#' 
+#' @param fileout str, a relative output file path
+#' @param site_data upstream `target`
+#' 
 nwis_site_info <- function(fileout, site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,25 @@
-process_data <- function(nwis_data){
-  nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, -tz_cd)
+#' Process raw NWIS data into format for plotting
+#' 
+#' Reformats raw NWIS data and combines with site metadata for use in plotting. Returns a table of reformatted data.
+#' 
+#'  @param nwis_data 
+#'  @param site_filename str, relative file path for NWIS gage metadata 
+
+process_data <- function(nwis_data, site_filename){
+  # load station metadata
+  site_info <- readr::read_csv(site_filename)
   
+  # reformat raw data and select columns of interest
+  nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
+    select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
+    left_join(., y = site_info, by = 'site_no') %>%
+    # join clean NWIS data with gage metadata
+    select(station_name = station_nm, site_no, dateTime, water_temperature,
+           latitude = dec_lat_va, longitude = dec_long_va) %>%
+    # reformat station names into factors for easier plotting
+    mutate(station_name = as.factor(station_name))
+
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
-  site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  
-  return(annotated_data)
-}
 
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
-}

--- a/remake.yml
+++ b/remake.yml
@@ -38,14 +38,8 @@ targets:
     command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
 
   site_data_clean:
-    command: process_data(site_data)
-
-  site_data_annotated:
-    command: annotate_data(site_data_clean, site_filename = '1_fetch/out/site_info.csv')
-
-  site_data_styled:
-    command: style_data(site_data_annotated)	
-
+    command: process_data(site_data, site_filename = '1_fetch/out/site_info.csv')
+  
   3_visualize/out/figure_1.png:
     command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 
-      site_data_styled)  
+      site_data_clean) 

--- a/remake.yml
+++ b/remake.yml
@@ -15,9 +15,25 @@ targets:
   all:
     depends: 3_visualize/out/figure_1.png
 
-  site_data:
-    command: download_nwis_data()
+  # site_data:
+  #   command: download_nwis_data()
+
+  # Download data
+  1_fetch/out/nwis_01427207.csv:
+    command: download_nwis_site_data(target_name)
   
+  1_fetch/out/nwis_01432160.csv:
+    command: download_nwis_site_data(target_name)
+  
+  1_fetch/out/nwis_01436690.csv:
+    command: download_nwis_site_data(target_name)
+  
+  1_fetch/out/nwis_01466500.csv:
+    command: download_nwis_site_data(target_name)
+    
+  site_data:
+    command: combine_site_data('1_fetch/out/nwis_01427207.csv', '1_fetch/out/nwis_01432160.csv', '1_fetch/out/nwis_01436690.csv', '1_fetch/out/nwis_01466500.csv')
+
   1_fetch/out/site_info.csv:
     command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
 


### PR DESCRIPTION
This pull request refactors the targets for `3_visualize/out/figure_1.png`

Primary activities include:
* Breaking `site_data` target into two steps: one for downloading data and one for combining data into `site_data` target
  * The data download portion of this target is brittle. Data are now downloaded and saved as CSVs in case there are data access issues in the future.
  * This format also allows for the straightforward inclusion/exclusion of additional NWIS gages
* Combining several downstream targets related to `site_data_*` into one. 
  *   Three targets were collapsed into one because they are relatively quick to run and combining them into one `dplyr` pipeline (with a few comments) leaves the function in human-readable state.