### PR TITLE
target type swap

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -24,10 +24,14 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01436690",
 #' @param fileout str, a relative output file path
 #' @param site_data upstream `target`
 #' 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(site_info, site_data_file){
+  # load station data
+  site_data <- readr::read_csv(site_data_file)
+  
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
+
+  return(site_info)
 }
 
 #' Combine NWIS files for specified gages
@@ -36,11 +40,12 @@ nwis_site_info <- function(fileout, site_data){
 #' 
 #' @param ... all upstream targets that should be combined for use in the downstream `site_data` target
 #' 
-combine_site_data <- function(...){
+combine_site_data <- function(fileout, ...){
   files_in <- c(...)
   data <- lapply(files_in, readr::read_csv, col_types = 'ccTdcc') %>% bind_rows()
   
-  return(data)
+  readr::write_csv(data, file = fileout)
+  # return(data)
 }
 
 #' a helper function called internally by `download_nwis_data()`

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -2,24 +2,26 @@
 #' 
 #' Reformats raw NWIS data and combines with site metadata for use in plotting. Returns a table of reformatted data.
 #' 
-#'  @param nwis_data 
+#'  @param fileout str, output location for file 
 #'  @param site_filename str, relative file path for NWIS gage metadata 
+#'  @param site_info target object
 
-process_data <- function(nwis_data, site_filename){
-  # load station metadata
-  site_info <- readr::read_csv(site_filename)
+process_data <- function(fileout, site_data_file, site_meta){
+  # load station data
+  nwis_data <- readr::read_csv(site_data_file)
   
   # reformat raw data and select columns of interest
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
-    left_join(., y = site_info, by = 'site_no') %>%
+    left_join(., y = site_meta, by = 'site_no') %>%
     # join clean NWIS data with gage metadata
     select(station_name = station_nm, site_no, dateTime, water_temperature,
            latitude = dec_lat_va, longitude = dec_long_va) %>%
     # reformat station names into factors for easier plotting
     mutate(station_name = as.factor(station_name))
 
-  return(nwis_data_clean)
+  # return(nwis_data_clean)
+  readr::write_csv(nwis_data_clean, file = fileout)
 }
 
 

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,5 +1,7 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
-  
+plot_nwis_timeseries <- function(fileout, site_data_clean_file, width = 12, height = 7, units = 'in'){
+  # load clean data
+  site_data_styled <- readr::read_csv(site_data_clean_file)
+
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)

--- a/remake.yml
+++ b/remake.yml
@@ -31,15 +31,22 @@ targets:
   1_fetch/out/nwis_01466500.csv:
     command: download_nwis_site_data(target_name)
     
-  site_data:
-    command: combine_site_data('1_fetch/out/nwis_01427207.csv', '1_fetch/out/nwis_01432160.csv', '1_fetch/out/nwis_01436690.csv', '1_fetch/out/nwis_01466500.csv')
+  # site_data:
+  1_fetch/out/site_data.csv:
+    command: combine_site_data(
+      target_name, 
+      '1_fetch/out/nwis_01427207.csv', 
+      '1_fetch/out/nwis_01432160.csv', 
+      '1_fetch/out/nwis_01436690.csv', 
+      '1_fetch/out/nwis_01466500.csv')
 
-  1_fetch/out/site_info.csv:
-    command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
+  # 1_fetch/out/site_info.csv:
+  site_info:
+    command: nwis_site_info(target_name, site_data_file = '1_fetch/out/site_data.csv')
 
-  site_data_clean:
-    command: process_data(site_data, site_filename = '1_fetch/out/site_info.csv')
+  # site_data_clean:
+  2_process/out/site_data_clean.csv:
+    command: process_data(target_name, site_data_file = '1_fetch/out/site_data.csv', site_info)
   
   3_visualize/out/figure_1.png:
-    command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 
-      site_data_clean) 
+    command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', site_data_clean_file = '2_process/out/site_data_clean.csv') 


### PR DESCRIPTION
This pull request is to practice swapping `target` object types.

* Convert one file target into an object target
  * `1_fetch/out/site_info.csv` to `site_info`

* Convert two file targets into object targets
  * `site_data` to `1_fetch/out/site_data.csv`
  * `site_data_clean` to `2_process/out/site_data_clean.csv`

Build status:
![image](https://user-images.githubusercontent.com/15007294/142477057-e7ded4e3-9279-4cdc-ab2c-f8045d2f1963.png)


Pipeline before swap:
![image](https://user-images.githubusercontent.com/15007294/142477113-d2b0d962-7c3b-4dd2-a277-b2d25058bb5b.png)



Pipeline after swap:
![image](https://user-images.githubusercontent.com/15007294/142476907-a9c4f249-1db3-481d-b9e7-6ced323440ff.png)
